### PR TITLE
support configuring SSLSocketFactory and OkHttpClient

### DIFF
--- a/src/test/java/com/launchdarkly/client/LDConfigTest.java
+++ b/src/test/java/com/launchdarkly/client/LDConfigTest.java
@@ -14,27 +14,27 @@ public class LDConfigTest {
   public void testConnectTimeoutSpecifiedInSeconds() {
     LDConfig config = new LDConfig.Builder().connectTimeout(3).build();
 
-    assertEquals(3000, config.connectTimeoutMillis);
+    assertEquals(3000, config.httpClient.connectTimeoutMillis());
   }
 
   @Test
   public void testConnectTimeoutSpecifiedInMilliseconds() {
     LDConfig config = new LDConfig.Builder().connectTimeoutMillis(3000).build();
 
-    assertEquals(3000, config.connectTimeoutMillis);
+    assertEquals(3000, config.httpClient.connectTimeoutMillis());
   }
   @Test
   public void testSocketTimeoutSpecifiedInSeconds() {
     LDConfig config = new LDConfig.Builder().socketTimeout(3).build();
 
-    assertEquals(3000, config.socketTimeoutMillis);
+    assertEquals(3000, config.httpClient.readTimeoutMillis());
   }
 
   @Test
   public void testSocketTimeoutSpecifiedInMilliseconds() {
     LDConfig config = new LDConfig.Builder().socketTimeoutMillis(3000).build();
 
-    assertEquals(3000, config.socketTimeoutMillis);
+    assertEquals(3000, config.httpClient.readTimeoutMillis());
   }
 
   @Test


### PR DESCRIPTION
This allows self-signed certs to be used for the relay proxy, which would be the case in environments where mTLS is used. Depends on https://github.com/launchdarkly/okhttp-eventsource/pull/35