### PR TITLE
upgrade connection error log from warn to error

### DIFF
--- a/src/main/java/com/launchdarkly/client/StreamProcessor.java
+++ b/src/main/java/com/launchdarkly/client/StreamProcessor.java
@@ -185,7 +185,7 @@ final class StreamProcessor implements UpdateProcessor {
 
       @Override
       public void onError(Throwable throwable) {
-        logger.warn("Encountered EventSource error: {}", throwable.toString());
+        logger.error("Encountered EventSource error: {}", throwable.toString());
         logger.debug(throwable.toString(), throwable);
       }
     };


### PR DESCRIPTION
We had a connectivity issue between the client and ld-relay due to some
misconfiguration. It resulted in apps not being able to connect to
LaunchDarkly for a long time.

It took a while to realize that the SDK actually logged a warning. It'd
be nice if this was an error, since at least for us, that gets sent to more noticeable places.