### PR TITLE
Replace FileComponents with FileData

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Be aware of two considerations when enabling the DEBUG log level:
 
 ## Using flag data from a file
 
-For testing purposes, the SDK can be made to read feature flag state from a file or files instead of connecting to LaunchDarkly. See <a href="http://javadoc.io/page/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/client/files/FileComponents.html">FileComponents</a> for more details.
+For testing purposes, the SDK can be made to read feature flag state from a file or files instead of connecting to LaunchDarkly. See <a href="https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/server/integrations/FileData.html">FileData</a> for more details.
 
 ## DNS caching issues
 


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

None.

**Describe the solution you've provided**

FileComponents was deprecated in 5.x. This updates the link in the readme.

**Describe alternatives you've considered**

It's a documentation change— unsure if there are other alternatives here.

**Additional context**

See CHANGELOG.md for 5.x about deprecation.
