### PR TITLE
fix(event-uri): resolve uri with any existing context path

### DIFF
--- a/src/main/java/com/launchdarkly/sdk/server/DefaultEventSender.java
+++ b/src/main/java/com/launchdarkly/sdk/server/DefaultEventSender.java
@@ -1,5 +1,6 @@
 package com.launchdarkly.sdk.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.launchdarkly.sdk.server.interfaces.BasicConfiguration;
 import com.launchdarkly.sdk.server.interfaces.EventSender;
 import com.launchdarkly.sdk.server.interfaces.EventSenderFactory;
@@ -160,6 +161,7 @@ final class DefaultEventSender implements EventSender {
     return null;
   }
 
+  @VisibleForTesting
   protected static URI appendPathToBaseURI(URI baseURI, String path) {
     return baseURI.resolve(baseURI.getPath().endsWith("/") ? path : (baseURI.getPath() + "/" + path));
   }

--- a/src/main/java/com/launchdarkly/sdk/server/DefaultEventSender.java
+++ b/src/main/java/com/launchdarkly/sdk/server/DefaultEventSender.java
@@ -91,7 +91,7 @@ final class DefaultEventSender implements EventSender {
       throw new IllegalArgumentException("kind"); // COVERAGE: unreachable code, those are the only enum values
     }
     
-    URI uri = eventsBaseUri.resolve(eventsBaseUri.getPath().endsWith("/") ? path : ("/" + path));
+    URI uri = appendPathToBaseURI(eventsBaseUri, path);
     Headers headers = headersBuilder.build();
     RequestBody body = RequestBody.create(data, JSON_CONTENT_TYPE);
     boolean mustShutDown = false;
@@ -158,6 +158,10 @@ final class DefaultEventSender implements EventSender {
       }
     }
     return null;
+  }
+
+  protected static URI appendPathToBaseURI(URI baseURI, String path) {
+    return baseURI.resolve(baseURI.getPath().endsWith("/") ? path : (baseURI.getPath() + "/" + path));
   }
   
   static final class Factory implements EventSenderFactory {

--- a/src/test/java/com/launchdarkly/sdk/server/DefaultEventSenderTest.java
+++ b/src/test/java/com/launchdarkly/sdk/server/DefaultEventSenderTest.java
@@ -5,9 +5,11 @@ import com.launchdarkly.sdk.server.interfaces.EventSender;
 import com.launchdarkly.sdk.server.interfaces.EventSenderFactory;
 import com.launchdarkly.sdk.server.interfaces.HttpConfiguration;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.Date;
@@ -67,6 +69,8 @@ public class DefaultEventSenderTest {
       assertThat(((DefaultEventSender)es).retryDelay, equalTo(DefaultEventSender.DEFAULT_RETRY_DELAY));
     }
   }
+
+
 
   @Test
   public void constructorUsesDefaultRetryDelayIfNotSpecified() throws Exception {
@@ -384,6 +388,46 @@ public class DefaultEventSenderTest {
       req = server.takeRequest(0, TimeUnit.SECONDS);
       assertThat(req, nullValue(RecordedRequest.class)); // only 2 requests total
     }
+  }
+
+  @Test
+  public void appendPathWithoutEndingSlash() throws URISyntaxException {
+    // if uri has a context
+    URI eventsBaseUri = new URI("https://www.example.com/context");
+    String path = "diagnostic";
+    URI uri = DefaultEventSender.appendPathToBaseURI(eventsBaseUri, path);
+    Assert.assertEquals(
+            "https://www.example.com/context/diagnostic",
+            uri.toString()
+    );
+
+    // if uri has no context
+    eventsBaseUri = new URI("https://www.example.com");
+    uri = DefaultEventSender.appendPathToBaseURI(eventsBaseUri, path);
+    Assert.assertEquals(
+            "https://www.example.com/diagnostic",
+            uri.toString()
+    );
+  }
+
+  @Test
+  public void appendPathWithEndingSlash() throws URISyntaxException {
+    // if uri has a context
+    URI eventsBaseUri = new URI("https://www.example.com/context/");
+    String path = "diagnostic";
+    URI uri = DefaultEventSender.appendPathToBaseURI(eventsBaseUri, path);
+    Assert.assertEquals(
+            "https://www.example.com/context/diagnostic",
+            uri.toString()
+    );
+
+    // if uri has no context
+    eventsBaseUri = new URI("https://www.example.com/");
+    uri = DefaultEventSender.appendPathToBaseURI(eventsBaseUri, path);
+    Assert.assertEquals(
+            "https://www.example.com/diagnostic",
+            uri.toString()
+    );
   }
 
   private MockResponse eventsSuccessResponse() {


### PR DESCRIPTION
**Requirements**

- [x ] I have added test coverage for new or changed functionality
- [ x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ x] I have validated my changes against all supported platform versions

**Related issues**
The way the URL is currently being resolved, it'd drop existing context paths if the uri didn't have a trailing `/`
Here's a sample unit tests that proves this bug
![Screen Shot 2020-09-23 at 12 27 33 PM](https://user-images.githubusercontent.com/5679105/94043780-58cfe800-fd9b-11ea-8f05-7f3a53e8fd74.png)


**Describe the solution you've provided**

if the URI doesn't have a trailing slash, still respect any existing context paths.

**Describe alternatives you've considered**
I tried providing a baseUri with trailing slash. But then another endpoint: /all, was attempting to add its own slash and failed since the baseuri already had one. 
So it seemed reasonable to me that this would just respect the context path provided to it regardless of it having trailing slash or not.


**Additional context**

I've added additional unit tests to cover the following scenarios:
- base uri has **no** context path of its own and has **no** trailing slash
- base uri has **no** context path of its own and has a trailing slash
- base uri has context path of its own and has **no** trailing slash
- base uri has context path of its own and has a trailing slash
