### PR TITLE
Adds proper Jigsaw Module Name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -438,6 +438,7 @@ def addOsgiManifest(jarTask, List<Configuration> importConfigs, List<Configurati
     def implementationVersion = version.replaceFirst('-.*$', '')
     jarTask.manifest {
         attributes(
+            "Automatic-Module-Name": "com.launchdarkly.sdk",
             "Implementation-Version": implementationVersion,
             "Bundle-SymbolicName": "com.launchdarkly.sdk",
             "Bundle-Version": implementationVersion,


### PR DESCRIPTION
Fixes #252

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

#252 

**Describe the solution you've provided**

Adds `Automatic-Module-Name` to Gradle's Jar Task configuration so it's properly picked up by Jigsaw.

**This will still need a proper `module-info.java` in the future, exposing only the public code. Internal should not be exposed**

**Describe alternatives you've considered**

N/A

**Additional context**

https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_modular