### PR TITLE
Rename master to main in .ldrelease/config.yml

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -17,7 +17,7 @@ jobs:
       name: gradle
 
 branches:
-  - name: master
+  - name: main
     description: 5.x
   - name: 4.x
 


### PR DESCRIPTION
This was already done in the private mirror, but need to repeat it here so I can run the next release via Releaser.