### PR TITLE
Update LDConfig.Builder startWait Javadoc now that it takes a Duration

### DIFF
--- a/src/main/java/com/launchdarkly/sdk/server/LDConfig.java
+++ b/src/main/java/com/launchdarkly/sdk/server/LDConfig.java
@@ -21,7 +21,10 @@ import java.time.Duration;
  * This class exposes advanced configuration options for the {@link LDClient}. Instances of this class must be constructed with a {@link com.launchdarkly.sdk.server.LDConfig.Builder}.
  */
 public final class LDConfig {
-  static final Duration DEFAULT_START_WAIT = Duration.ofSeconds(5);
+  /**
+   * The default value for {@link Builder#startWait(Duration)}: 5 seconds.
+   */
+  public static final Duration DEFAULT_START_WAIT = Duration.ofSeconds(5);
   
   protected static final LDConfig DEFAULT = new Builder().build();
 
@@ -286,7 +289,8 @@ public final class LDConfig {
     /**
      * Set how long the constructor will block awaiting a successful connection to LaunchDarkly.
      * Setting this to a zero or negative duration will not block and cause the constructor to return immediately.
-     * Default value: 5000
+     * <p>
+     * The default is {@link #DEFAULT_START_WAIT}.
      *
      * @param startWait maximum time to wait; null to use the default
      * @return the builder


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality (N/A)
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions (N/A)

**Describe the solution you've provided**

Fix the Javadoc for `LDConfig.Builder.startWait`. It still said "Default value: 5000" despite now taking a `Duration`. To clarify that the default is 5 seconds, the Javadoc now refers to the `DEFAULT_START_WAIT` constant. This matches the Javadoc for [`HttpConfigurationBuilder.connectTimeout`](https://github.com/launchdarkly/java-server-sdk/blob/main/src/main/java/com/launchdarkly/sdk/server/integrations/HttpConfigurationBuilder.java#L55-L67) and [`HttpConfigurationBuilder.socketTimeout`](https://github.com/launchdarkly/java-server-sdk/blob/main/src/main/java/com/launchdarkly/sdk/server/integrations/HttpConfigurationBuilder.java#L94-L108).